### PR TITLE
chore(android): bump kotlin, gradle and aar version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,9 +54,9 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation "com.capacitorjs:osinappbrowser-android:1.0.0"
+    implementation "com.capacitorjs:osinappbrowser-android:1.2.0"
     implementation 'androidx.browser:browser:1.8.0'
-    implementation "androidx.constraintlayout:constraintlayout:2.2.0-alpha13"
+    implementation "androidx.constraintlayout:constraintlayout:2.2.0"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation "junit:junit:$junitVersion"

--- a/example-app/android/variables.gradle
+++ b/example-app/android/variables.gradle
@@ -1,15 +1,15 @@
 ext {
     minSdkVersion = 26
-    compileSdkVersion = 34
-    targetSdkVersion = 34
+    compileSdkVersion = 35
+    targetSdkVersion = 35
     androidxActivityVersion = '1.8.0'
-    androidxAppCompatVersion = '1.6.1'
+    androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'
     androidxCoreVersion = '1.12.0'
     androidxFragmentVersion = '1.6.2'
     coreSplashScreenVersion = '1.0.1'
     androidxWebkitVersion = '1.9.0'
-    junitVersion = '4.13.2'
+    junitVersion = '4.13.3'
     androidxJunitVersion = '1.1.5'
     androidxEspressoCoreVersion = '3.5.1'
     cordovaAndroidVersion = '10.1.1'


### PR DESCRIPTION
### Description
This PR bumps kotlin, gradle and aar versions

fix for:
- https://github.com/ionic-team/capacitor-os-inappbrowser/issues/30
- https://github.com/ionic-team/capacitor-plugins/issues/2226