### PR TITLE
Fix: basic_tests github action

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -10,16 +10,16 @@ jobs:
   setup:
     uses: ./.github/workflows/reusable_setup.yml
     secrets:
-      CAP_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+      THE_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
 
   lint-test:
     needs: 'setup'
     uses: ./.github/workflows/reusable_lint.yml
     secrets:
-      CAP_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+      THE_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
 
   build-packages:
     needs: 'setup'
     uses: ./.github/workflows/reusable_build.yml
     secrets:
-      CAP_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
+      THE_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_lint.yml
+++ b/.github/workflows/reusable_lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: 'macos-12'
+    runs-on: 'macos-14'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -10,7 +10,7 @@ jobs:
   setup:
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12']
+        os: ['ubuntu-22.04', 'macos-14']
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Currently the github action `basic_tests.yml` kept failing, this PR fixes it by:
- Correctly referencing token
- Updating deprecated macos runner