### PR TITLE
Remove unnecessary permissions from AndroidManifest.xml

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation "com.capacitorjs:osinappbrowser-android:1.2.0"
+    implementation "com.capacitorjs:osinappbrowser-android:1.2.1"
     implementation 'androidx.browser:browser:1.8.0'
     implementation "androidx.constraintlayout:constraintlayout:2.2.0"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/inappbrowser",
-  "version": "1.1.0-dev.2",
+  "version": "1.1.1",
   "description": "The InAppBrowser Plugin provides a web browser view that allows you to load any web page externally. It behaves as a standard web browser and is useful to load untrusted content without risking your application's security. It offers three different ways to open URLs; in a WebView, in an in-app system browser (Custom Tabs for Android and SFSafariViewController for iOS), and in the device's default browser.",
   "main": "./dist/plugin.cjs",
   "module": "./dist/plugin.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/inappbrowser",
-  "version": "1.1.1",
+  "version": "1.1.0-dev.2",
   "description": "The InAppBrowser Plugin provides a web browser view that allows you to load any web page externally. It behaves as a standard web browser and is useful to load untrusted content without risking your application's security. It offers three different ways to open URLs; in a WebView, in an in-app system browser (Custom Tabs for Android and SFSafariViewController for iOS), and in the device's default browser.",
   "main": "./dist/plugin.cjs",
   "module": "./dist/plugin.mjs",


### PR DESCRIPTION
- Updates the dependency to `OSInAppBrowserLib-Android`, removing unnecessary dependencies from the `AndroidManifest.xml` file.

Fixes https://github.com/ionic-team/capacitor-os-inappbrowser/issues/29