### PR TITLE
fix(android): Unknown Kotlin JVM target 21

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,10 @@ android {
     }
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 repositories {
     google()
     mavenCentral()

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -48,7 +48,7 @@
     },
     "..": {
       "name": "@capacitor/inappbrowser",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^6.0.0",


### PR DESCRIPTION
If the user has a default version of JVM set to 21, the android build may fail with `Unknown Kotlin JVM target: 21` because the plugin's kotlin version (1.9.10) is not fully compatible with JVM 21.

Since this plugin is meant to use Java 17, this PR explicitly sets that version for kotlin to use.