### PR TITLE
fix(android): native lib causes app compilation to fail

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation "com.capacitorjs:osinappbrowser-android:1.2.1"
+    implementation "com.capacitorjs:osinappbrowser-android:1.2.1@aar"
     implementation 'androidx.browser:browser:1.8.0'
     implementation "androidx.constraintlayout:constraintlayout:2.2.0-alpha13"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"


### PR DESCRIPTION
Using OSInAppBrowserLib-Android with 1.x plugin, that assumes Capacitor 7 compileSdk 34, causes apps to fail compilation due to transitive dependencies requiring compileSdk 35: 

```
Dependency 'androidx.core:core-ktx:1.15.0' requires libraries and applications that
      depend on it to compile against version 35 or later of the
      Android APIs.
```

By using `@aar`, the transitive dependencies are no longer passed to the plugin / app.

This would cause issues if some of the dependencies were missing, but they're all declared by capacitor, and using different version didn't affect the native Android app at all, from my tests.