### PR TITLE
chore: update dependency to Android native lib

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -9,17 +9,11 @@ on:
 jobs:
   setup:
     uses: ./.github/workflows/reusable_setup.yml
-    secrets:
-      THE_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
 
   lint-test:
     needs: 'setup'
     uses: ./.github/workflows/reusable_lint.yml
-    secrets:
-      THE_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
 
   build-packages:
     needs: 'setup'
     uses: ./.github/workflows/reusable_build.yml
-    secrets:
-      THE_GH_RELEASE_TOKEN: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       THE_GH_RELEASE_TOKEN:
-        required: true
+        required: false
 
 jobs:
   build:
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.THE_GH_RELEASE_TOKEN }}
+          token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}
 
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/reusable_lint.yml
+++ b/.github/workflows/reusable_lint.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       THE_GH_RELEASE_TOKEN:
-        required: true
+        required: false
 
 jobs:
   lint:
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.THE_GH_RELEASE_TOKEN }}
+          token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}
 
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       THE_GH_RELEASE_TOKEN:
-        required: true
+        required: false
 
 jobs:
   setup:
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.THE_GH_RELEASE_TOKEN }}
+          token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}
 
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation "com.capacitorjs:osinappbrowser-android:1.2.1"
+    implementation "io.ionic.libs:ioninappbrowser-android:1.2.1"
     implementation 'androidx.browser:browser:1.8.0'
     implementation "androidx.constraintlayout:constraintlayout:2.2.0"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"


### PR DESCRIPTION
- Updates dependency to Android native lib to fetch it from `io.ionic.libs`
- Also updates basis-tests and other CI workflows (except Release) to use GitHub's token when the repo's token is not available.