### PR TITLE
fix(ios): Assign showNavigationButtons in WebViewOptions

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/OSInAppBrowserWebViewModel.swift
+++ b/ios/Sources/InAppBrowserPlugin/OSInAppBrowserWebViewModel.swift
@@ -90,6 +90,7 @@ extension OSInAppBrowserWebViewModel {
             mediaPlaybackRequiresUserAction: self.mediaPlaybackRequiresUserAction,
             closeButtonText: self.closeButtonText,
             toolbarPosition: self.toolbarPosition,
+            showNavigationButtons: self.showNavigationButtons,
             leftToRight: self.leftToRight,
             allowOverScroll: self.iOS.allowOverScroll,
             enableViewportScale: self.iOS.enableViewportScale,


### PR DESCRIPTION
**Description**
This PR assigns values to the `showNavigationButtons` prop in the WebViewOptions.

**Fix for:**
* [[Bug] iOS showNavigationButtons prop is not being set #49](https://github.com/ionic-team/capacitor-os-inappbrowser/issues/49)

**Tests**
Testing for Capacitor 6
* `showNavigationButtons=false` on iOS in /example-app
* `showNavigationButtons=true` on iOS in /example-app

Testing for Capacitor 7
* `showNavigationButtons=false` on iOS in /example-app
* `showNavigationButtons=true` on iOS in /example-app