### PR TITLE
fix: export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/plugin.mjs",


### PR DESCRIPTION
package.json is not exported from package.json, this causes it to hit the fallback in the resolveNode function of the capacitor-cli