### PR TITLE
fix(android,ios): properly return errors

### DIFF
--- a/android/src/main/java/com/capacitorjs/osinappbrowser/InAppBrowserPlugin.kt
+++ b/android/src/main/java/com/capacitorjs/osinappbrowser/InAppBrowserPlugin.kt
@@ -54,7 +54,7 @@ class InAppBrowserPlugin : Plugin() {
                 }
             }
         } catch (e: Exception) {
-            sendErrorResult(call, OSInAppBrowserError.GeneralError(url, OSInAppBrowserTarget.EXTERNAL_BROWSER, e))
+            sendErrorResult(call, OSInAppBrowserError.OpenFailed(url, OSInAppBrowserTarget.EXTERNAL_BROWSER))
         }
     }
 
@@ -101,7 +101,7 @@ class InAppBrowserPlugin : Plugin() {
                 }
             }
         } catch (e: Exception) {
-            sendErrorResult(call, OSInAppBrowserError.GeneralError(url, OSInAppBrowserTarget.SYSTEM_BROWSER, e))
+            sendErrorResult(call, OSInAppBrowserError.OpenFailed(url, OSInAppBrowserTarget.SYSTEM_BROWSER))
         }
     }
 
@@ -148,7 +148,7 @@ class InAppBrowserPlugin : Plugin() {
                 }
             }
         } catch (e: Exception) {
-            sendErrorResult(call, OSInAppBrowserError.GeneralError(url, OSInAppBrowserTarget.WEB_VIEW, e))
+            sendErrorResult(call, OSInAppBrowserError.OpenFailed(url, OSInAppBrowserTarget.WEB_VIEW))
         }
 
     }

--- a/android/src/main/java/com/capacitorjs/osinappbrowser/InAppBrowserPlugin.kt
+++ b/android/src/main/java/com/capacitorjs/osinappbrowser/InAppBrowserPlugin.kt
@@ -34,12 +34,12 @@ class InAppBrowserPlugin : Plugin() {
     fun openInExternalBrowser(call: PluginCall) {
         val url = call.getString("url")
         if (url.isNullOrEmpty()) {
-            call.reject("The value of the 'url' input parameter of the 'openInExternalBrowser' action is missing or is empty.")
+            sendErrorResult(call, OSInAppBrowserError.InputArgumentsIssue(OSInAppBrowserTarget.EXTERNAL_BROWSER))
             return
         }
 
         if (!isSchemeValid(url)) {
-            call.reject("The URL provided must begin with either http:// or https://.")
+            sendErrorResult(call, OSInAppBrowserError.InvalidURL)
             return
         }
 
@@ -50,11 +50,11 @@ class InAppBrowserPlugin : Plugin() {
                 if (success) {
                     call.resolve()
                 } else {
-                    call.reject("External browser couldn't open the following URL: '$url'")
+                    sendErrorResult(call, OSInAppBrowserError.OpenFailed(url, OSInAppBrowserTarget.EXTERNAL_BROWSER))
                 }
             }
         } catch (e: Exception) {
-            call.reject("An error occurred while trying to open the external browser: ${e.message}")
+            sendErrorResult(call, OSInAppBrowserError.GeneralError(url, OSInAppBrowserTarget.EXTERNAL_BROWSER, e))
         }
     }
 
@@ -63,18 +63,13 @@ class InAppBrowserPlugin : Plugin() {
         val url = call.getString("url")
         val options = call.getObject("options")
 
-        if (url.isNullOrEmpty()) {
-            call.reject("The value of the 'url' input parameter of the 'openInSystemBrowser' action is missing or is empty.")
+        if (url.isNullOrEmpty() || options == null) {
+            sendErrorResult(call, OSInAppBrowserError.InputArgumentsIssue(OSInAppBrowserTarget.SYSTEM_BROWSER))
             return
         }
 
         if (!isSchemeValid(url)) {
-            call.reject("The URL provided must begin with either http:// or https://.")
-            return
-        }
-
-        if (options == null) {
-            call.reject("The value of the 'options' input parameter of the 'openInSystemBrowser' action is missing or isn't valid.")
+            sendErrorResult(call, OSInAppBrowserError.InvalidURL)
             return
         }
 
@@ -101,12 +96,12 @@ class InAppBrowserPlugin : Plugin() {
                         activeRouter = customTabsRouter
                         call.resolve()
                     } else {
-                        call.reject("Custom Tabs couldn't open the following URL:'$url'")
+                        sendErrorResult(call, OSInAppBrowserError.OpenFailed(url, OSInAppBrowserTarget.SYSTEM_BROWSER))
                     }
                 }
             }
         } catch (e: Exception) {
-            call.reject("An error occurred while trying to open Custom Tabs: ${e.message}")
+            sendErrorResult(call, OSInAppBrowserError.GeneralError(url, OSInAppBrowserTarget.SYSTEM_BROWSER, e))
         }
     }
 
@@ -115,30 +110,25 @@ class InAppBrowserPlugin : Plugin() {
         val url = call.getString("url")
         val options = call.getObject("options")
 
-        if (url.isNullOrEmpty()) {
-            call.reject("The value of the 'url' input parameter of the 'openInWebView' action is missing or is empty.")
+        if (url.isNullOrEmpty() || options == null) {
+            sendErrorResult(call, OSInAppBrowserError.InputArgumentsIssue(OSInAppBrowserTarget.WEB_VIEW))
             return
         }
 
         if (!isSchemeValid(url)) {
-            call.reject("The URL provided must begin with either http:// or https://.")
-            return
-        }
-
-        if (options == null) {
-            call.reject("The value of the 'options' input parameter of the 'openInWebView' action is missing or isn't valid.")
+            sendErrorResult(call, OSInAppBrowserError.InvalidURL)
             return
         }
 
         try {
             // Try closing active router before continuing to open
             close {
-                val options = buildWebViewOptions(call.getObject("options"))
+                val webViewOptions = buildWebViewOptions(options)
 
                 val webViewRouter = OSIABWebViewRouterAdapter(
                     context = context,
                     lifecycleScope = activity.lifecycleScope,
-                    options = options,
+                    options = webViewOptions,
                     flowHelper = OSIABFlowHelper(),
                     onBrowserPageLoaded = {
                         notifyListeners(OSIABEventType.BROWSER_PAGE_LOADED.value, null)
@@ -153,12 +143,12 @@ class InAppBrowserPlugin : Plugin() {
                         activeRouter = webViewRouter
                         call.resolve()
                     } else {
-                        call.reject("The WebView couldn't open the following URL: '$url'")
+                        sendErrorResult(call, OSInAppBrowserError.OpenFailed(url, OSInAppBrowserTarget.WEB_VIEW))
                     }
                 }
             }
         } catch (e: Exception) {
-            call.reject("An error occurred while trying to open the WebView: ${e.message}")
+            sendErrorResult(call, OSInAppBrowserError.GeneralError(url, OSInAppBrowserTarget.WEB_VIEW, e))
         }
 
     }
@@ -169,7 +159,7 @@ class InAppBrowserPlugin : Plugin() {
             if (success) {
                 call.resolve()
             } else {
-                call.reject("There's no browser view to close.")
+                sendErrorResult(call, OSInAppBrowserError.CloseFailed)
             }
         }
     }
@@ -273,6 +263,16 @@ class InAppBrowserPlugin : Plugin() {
     private fun isSchemeValid(url: String): Boolean {
         return listOf("http://", "https://").any { url.startsWith(it, true) }
     }
+
+    /**
+     * Helper method to send an error result using call.reject
+     * @param call The PluginCall object to send the error result
+     * @param error The OSInAppBrowserError object to send as the error result
+     */
+    private fun sendErrorResult(call: PluginCall, error: OSInAppBrowserError) {
+        call.reject(error.message, error.code)
+    }
+
 
 }
 

--- a/android/src/main/java/com/capacitorjs/osinappbrowser/OSInAppBrowserError.kt
+++ b/android/src/main/java/com/capacitorjs/osinappbrowser/OSInAppBrowserError.kt
@@ -20,11 +20,6 @@ sealed class OSInAppBrowserError(val code: String, val message: String) {
         code = 3.formatErrorCode(),
         message = "The URL provided must begin with either http:// or https://."
     )
-
-    data class GeneralError(val url: String, val target: OSInAppBrowserTarget, val exception: Exception) : OSInAppBrowserError(
-        code = target.generalErrorCode.formatErrorCode(),
-        message = "An error occurred while trying to open the '${target.openFailedText}': ${exception.message}"
-    )
 }
 
 enum class OSInAppBrowserTarget(
@@ -32,11 +27,10 @@ enum class OSInAppBrowserTarget(
     val inputIssueText: String,
     val openFailedCode: Int,
     val openFailedText: String,
-    val generalErrorCode: Int
 ) {
-    EXTERNAL_BROWSER(5, "openInExternalBrowser", 8, "External browser", 13),
-    SYSTEM_BROWSER(6, "openInSystemBrowser", 10, "Custom Tabs", 14),
-    WEB_VIEW(7, "openInWebView", 11, "The WebView", 15)
+    EXTERNAL_BROWSER(5, "openInExternalBrowser", 8, "External browser"),
+    SYSTEM_BROWSER(6, "openInSystemBrowser", 10, "Custom Tabs"),
+    WEB_VIEW(7, "openInWebView", 11, "The WebView")
 }
 
 private fun Int.formatErrorCode(): String {

--- a/android/src/main/java/com/capacitorjs/osinappbrowser/OSInAppBrowserError.kt
+++ b/android/src/main/java/com/capacitorjs/osinappbrowser/OSInAppBrowserError.kt
@@ -1,0 +1,44 @@
+package com.capacitorjs.osinappbrowser
+
+sealed class OSInAppBrowserError(val code: String, val message: String) {
+    data class InputArgumentsIssue(val target: OSInAppBrowserTarget) : OSInAppBrowserError(
+        code = target.inputIssueCode.formatErrorCode(),
+        message = "The '${target.inputIssueText}' input parameters aren't valid."
+    )
+
+    data class OpenFailed(val url: String, val target: OSInAppBrowserTarget) : OSInAppBrowserError(
+        code = target.openFailedCode.formatErrorCode(),
+        message = "${target.openFailedText} couldn't open the following URL: $url"
+    )
+
+    data object CloseFailed : OSInAppBrowserError(
+        code = 12.formatErrorCode(),
+        message = "There's no browser view to close."
+    )
+
+    data object InvalidURL : OSInAppBrowserError(
+        code = 3.formatErrorCode(),
+        message = "The URL provided must begin with either http:// or https://."
+    )
+
+    data class GeneralError(val url: String, val target: OSInAppBrowserTarget, val exception: Exception) : OSInAppBrowserError(
+        code = target.generalErrorCode.formatErrorCode(),
+        message = "An error occurred while trying to open the '${target.openFailedText}': ${exception.message}"
+    )
+}
+
+enum class OSInAppBrowserTarget(
+    val inputIssueCode: Int,
+    val inputIssueText: String,
+    val openFailedCode: Int,
+    val openFailedText: String,
+    val generalErrorCode: Int
+) {
+    EXTERNAL_BROWSER(5, "openInExternalBrowser", 8, "External browser", 13),
+    SYSTEM_BROWSER(6, "openInSystemBrowser", 10, "Custom Tabs", 14),
+    WEB_VIEW(7, "openInWebView", 11, "The WebView", 15)
+}
+
+private fun Int.formatErrorCode(): String {
+    return "OS-PLUG-IABP-" + this.toString().padStart(4, '0')
+}

--- a/example-app/android/capacitor.settings.gradle
+++ b/example-app/android/capacitor.settings.gradle
@@ -3,16 +3,16 @@ include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/.pnpm/@capacitor+android@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/android/capacitor')
 
 include ':capacitor-app'
-project(':capacitor-app').projectDir = new File('../node_modules/.pnpm/@capacitor+app@7.0.0-alpha.2_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/app/android')
+project(':capacitor-app').projectDir = new File('../node_modules/.pnpm/@capacitor+app@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/app/android')
 
 include ':capacitor-haptics'
-project(':capacitor-haptics').projectDir = new File('../node_modules/.pnpm/@capacitor+haptics@7.0.0-alpha.2_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/haptics/android')
+project(':capacitor-haptics').projectDir = new File('../node_modules/.pnpm/@capacitor+haptics@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/haptics/android')
 
 include ':capacitor-inappbrowser'
 project(':capacitor-inappbrowser').projectDir = new File('../node_modules/@capacitor/inappbrowser/android')
 
 include ':capacitor-keyboard'
-project(':capacitor-keyboard').projectDir = new File('../node_modules/.pnpm/@capacitor+keyboard@7.0.0-alpha.2_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/keyboard/android')
+project(':capacitor-keyboard').projectDir = new File('../node_modules/.pnpm/@capacitor+keyboard@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/keyboard/android')
 
 include ':capacitor-status-bar'
-project(':capacitor-status-bar').projectDir = new File('../node_modules/.pnpm/@capacitor+status-bar@7.0.0-alpha.2_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/status-bar/android')
+project(':capacitor-status-bar').projectDir = new File('../node_modules/.pnpm/@capacitor+status-bar@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/status-bar/android')

--- a/example-app/ios/App/Podfile
+++ b/example-app/ios/App/Podfile
@@ -11,11 +11,11 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/.pnpm/@capacitor+ios@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/.pnpm/@capacitor+ios@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/ios'
-  pod 'CapacitorApp', :path => '../../node_modules/.pnpm/@capacitor+app@7.0.0-alpha.2_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/app'
-  pod 'CapacitorHaptics', :path => '../../node_modules/.pnpm/@capacitor+haptics@7.0.0-alpha.2_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/haptics'
-  pod 'CapacitorInappbrowser', :path => '../../node_modules/.pnpm/file+.._@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/inappbrowser'
-  pod 'CapacitorKeyboard', :path => '../../node_modules/.pnpm/@capacitor+keyboard@7.0.0-alpha.2_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/keyboard'
-  pod 'CapacitorStatusBar', :path => '../../node_modules/.pnpm/@capacitor+status-bar@7.0.0-alpha.2_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/status-bar'
+  pod 'CapacitorApp', :path => '../../node_modules/.pnpm/@capacitor+app@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/app'
+  pod 'CapacitorHaptics', :path => '../../node_modules/.pnpm/@capacitor+haptics@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/haptics'
+  pod 'CapacitorInappbrowser', :path => '../../node_modules/.pnpm/@capacitor+inappbrowser@file+.._@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/inappbrowser'
+  pod 'CapacitorKeyboard', :path => '../../node_modules/.pnpm/@capacitor+keyboard@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/keyboard'
+  pod 'CapacitorStatusBar', :path => '../../node_modules/.pnpm/@capacitor+status-bar@7.0.0-rc.0_@capacitor+core@7.0.0-rc.0/node_modules/@capacitor/status-bar'
 end
 
 target 'App' do

--- a/example-app/src/pages/Home.tsx
+++ b/example-app/src/pages/Home.tsx
@@ -10,10 +10,19 @@ const Home: React.FC = () => {
     });
   }
 
-  const invalidScheme = () => {
-    InAppBrowser.openInExternalBrowser({
-      url: "mailto://mail@outsystems.com"
-    });
+  const invalidScheme = async () => {
+    try {
+      const result = await InAppBrowser.openInExternalBrowser({
+        url: "mailto://mail@outsystems.com"
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        alert("Error: " + (error as any).code + ": " + error.message);
+      } else {
+        alert("Error: Unknown error");
+      }
+    }
+    
   }
 
   const openInSystemBrowserWithDefaults = () => {

--- a/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
+++ b/ios/Sources/InAppBrowserPlugin/InAppBrowserPlugin.swift
@@ -201,7 +201,7 @@ private extension InAppBrowserPlugin {
     }
 
     func error(_ call: CAPPluginCall, type errorType: OSInAppBrowserError) {
-        call.reject(errorType.description)
+        call.reject(errorType.description, errorType.code)
     }
 }
 

--- a/ios/Sources/InAppBrowserPlugin/OSInAppBrowserError.swift
+++ b/ios/Sources/InAppBrowserPlugin/OSInAppBrowserError.swift
@@ -62,7 +62,7 @@ enum OSInAppBrowserError: Error {
         case .noBrowserToClose:
             baseCode = 12
         case .bridgeNotInitialised:
-            baseCode = 16
+            baseCode = 13
         }
         return "OS-PLUG-IABP-\(String(format: "%04d", baseCode))"
     }

--- a/ios/Sources/InAppBrowserPlugin/OSInAppBrowserError.swift
+++ b/ios/Sources/InAppBrowserPlugin/OSInAppBrowserError.swift
@@ -41,4 +41,30 @@ enum OSInAppBrowserError: Error {
 
         return result
     }
+    
+    var code: String {
+        let baseCode: Int
+        switch self {
+        case .invalidURLScheme:
+            baseCode = 3
+        case .inputArgumentsIssue(let target):
+            baseCode = switch target {
+                case .externalBrowser: 5
+                case .systemBrowser: 6
+                case .webView: 7
+            }
+        case .failedToOpen(_, let target):
+            baseCode = switch target {
+                case .externalBrowser: 8
+                case .systemBrowser: 9
+                case .webView: 11
+            }
+        case .noBrowserToClose:
+            baseCode = 12
+        case .bridgeNotInitialised:
+            baseCode = 16
+        }
+        return "OS-PLUG-IABP-\(String(format: "%04d", baseCode))"
+    }
+    
 }


### PR DESCRIPTION
## Changes
- Fixes Android and iOS native code to return both an error message and code, instead of simply returning a message. This is necessary for this plugin to be aligned with its Cordova counterpart, and to be used by OutSystems apps.
- Also updates the `example-app` to show the error that is returned in `invalidScheme`.

## Tests
- Tested with `example-app.`
- Tested with OutSystems app using the Capacitor plugin.