### PR TITLE
fix(ios): include showNavigationButtons in conversion function

### DIFF
--- a/ios/Sources/InAppBrowserPlugin/OSInAppBrowserWebViewModel.swift
+++ b/ios/Sources/InAppBrowserPlugin/OSInAppBrowserWebViewModel.swift
@@ -90,6 +90,7 @@ extension OSInAppBrowserWebViewModel {
             mediaPlaybackRequiresUserAction: self.mediaPlaybackRequiresUserAction,
             closeButtonText: self.closeButtonText,
             toolbarPosition: self.toolbarPosition,
+            showNavigationButtons: self.showNavigationButtons,
             leftToRight: self.leftToRight,
             allowOverScroll: self.iOS.allowOverScroll,
             enableViewportScale: self.iOS.enableViewportScale,


### PR DESCRIPTION
## Changes
- Fixes iOS bridge by adding `showNavigationButtons` in conversion function. This bug meant that this option wasn't passed to the library, and the default value of `true` was always used.

## Tests
- Tested with OutSystems app using the Capacitor plugin.