### PR TITLE
docs: browserPageNavigationCompleted only for openInWebView

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Closes the currently active browser. It can be used to close browsers launched t
 addListener(eventName: 'browserClosed' | 'browserPageLoaded', listenerFunc: () => void) => Promise<PluginListenerHandle>
 ```
 
-Adds a listener for the specified browser event.
+Adds a listener for the specified browser events, with no data being returned.
 
 | Param              | Type                                                | Description                                                                          |
 | ------------------ | --------------------------------------------------- | ------------------------------------------------------------------------------------ |
@@ -178,12 +178,12 @@ Adds a listener for the specified browser event.
 addListener(eventName: 'browserPageNavigationCompleted', listenerFunc: (data: BrowserPageNavigationCompletedEventData) => void) => Promise<PluginListenerHandle>
 ```
 
-Adds a listener for the specified browser event.
+Adds a listener for the specified browser event, which receives data.
 
-| Param              | Type                                                                                                                           | Description                                                                    |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| **`eventName`**    | <code>'browserPageNavigationCompleted'</code>                                                                                  | The name of the browser event to listen for: 'browserPageNavigationCompleted'. |
-| **`listenerFunc`** | <code>(data: <a href="#browserpagenavigationcompletedeventdata">BrowserPageNavigationCompletedEventData</a>) =&gt; void</code> | The function to be called when the event occurs.                               |
+| Param              | Type                                                                                                                           | Description                                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code>'browserPageNavigationCompleted'</code>                                                                                  | The name of the browser event to listen for: 'browserPageNavigationCompleted'. Applies only to openInWebView. |
+| **`listenerFunc`** | <code>(data: <a href="#browserpagenavigationcompletedeventdata">BrowserPageNavigationCompletedEventData</a>) =&gt; void</code> | The function to be called when the event occurs.                                                              |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -200,7 +200,7 @@ export interface InAppBrowserPlugin {
   close(): Promise<void>;
 
   /**
-   * Adds a listener for the specified browser event.
+   * Adds a listener for the specified browser events, with no data being returned.
    * @param eventName The name of the browser event to listen for: 'browserClosed' or 'browserPageLoaded'.
    * @param listenerFunc The function to be called when the event occurs.
    */
@@ -210,8 +210,8 @@ export interface InAppBrowserPlugin {
   ): Promise<PluginListenerHandle>;
 
   /**
-   * Adds a listener for the specified browser event.
-   * @param eventName The name of the browser event to listen for: 'browserPageNavigationCompleted'.
+   * Adds a listener for the specified browser event, which receives data.
+   * @param eventName The name of the browser event to listen for: 'browserPageNavigationCompleted'. Applies only to openInWebView.
    * @param listenerFunc The function to be called when the event occurs.
    */
   addListener(


### PR DESCRIPTION
The issue https://github.com/ionic-team/capacitor-os-inappbrowser/issues/60 highlights that it is not clear where browserPageNavigationCompleted is available.

This small PR updates the API docs to explicitly state it only works for `openInWebView`.