### PR TITLE
chore(cicd): Fix release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
     contents: write
     issues: write
     deployments: write
+    id-token: write # to enable use of OIDC for npm provenance
 
 jobs:
   setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - development
       - next
-      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Release"
 on:
   push:
     branches:
-      - dev
+      - development
       - next
       - main
   workflow_dispatch:

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
   branches: [
     { name: 'main', channel: 'latest' },
     { name: 'next', channel: 'next', prerelease: true },
-    { name: 'dev', channel: 'dev', prerelease: true }
+    { name: 'development', channel: 'dev', prerelease: true }
   ],
   repositoryUrl: 'https://github.com/ionic-team/capacitor-os-inappbrowser.git',
   plugins: [


### PR DESCRIPTION
Update release GitHub action in the following ways:

- Adding missing `id-token` permission.
- Correct branch name for dev tag releases.
- Not run automatically on push to main. The reason I changed this is because this way we can choose when to release a stable, in case we want to bundle multiple features / fixes. Releases are still running automatically for non-stable branches.