### PR TITLE
feat(android): add pdf support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation("io.ionic.libs:ioninappbrowser-android:1.4.1")
+    implementation("io.ionic.libs:ioninappbrowser-android:1.5.0")
     implementation 'androidx.browser:browser:1.8.0'
     implementation "androidx.constraintlayout:constraintlayout:2.2.0"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"


### PR DESCRIPTION
Update the ioninappbrowser-android dependency to version 1.5.0, which adds support for opening PDF files on Android. This enables in-app PDF viewing without requiring external apps.