### PR TITLE
Fixes an issue with reimports in mono-repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/plugin.mjs",
       "require": "./dist/plugin.cjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "unpkg": "dist/plugin.js",
   "files": [


### PR DESCRIPTION
If reimporting the package in a mono-repo project, the plugin is not synced by executing `npx cap sync`. This is not the case with most other plugins due to having a different package.json structure.

Project package.json that is used to derive the plugins to be synced from looks like following. 

```json
{
  "name": "my-app",
  "dependencies": {
    "@capacitor/android": "../../../node_modules/@capacitor/android",
    "@capacitor/app": "../../../node_modules/@capacitor/app",
    "@capacitor/haptics": "../../../node_modules/@capacitor/haptics",
    "@capacitor/inappbrowser": "../../../node_modules/@capacitor/inappbrowser",
    "@capacitor/keyboard": "../../../node_modules/@capacitor/keyboard",
    "@capacitor/ios": "../../../node_modules/@capacitor/ios",
    "@capacitor/preferences": "../../../node_modules/@capacitor/preferences",
    "@capacitor/status-bar": "../../../node_modules/@capacitor/status-bar"
  },
  "devDependencies": {
    "@capacitor/cli": "../../../node_modules/@capacitor/cli"
  }
}
```