### PR TITLE
fix(ios): use version instead of branch for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["InAppBrowserPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0"),
         .package(url: "https://github.com/OutSystems/OSInAppBrowserLib-iOS.git", from: "2.2.0")
     ],
     targets: [


### PR DESCRIPTION
main branch contains all the versions and latest can be 6.x, 7.x or 8.x depending on the latest released version, so that can cause issues if pointing to main branch