### PR TITLE
chore(ci): upgrade github actions to v5/v6

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22 # semantic-release requires at least this version
     - name: Update npm # To ensure npm 11.5.1 or later is installed for Trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_lint.yml
+++ b/.github/workflows/reusable_lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'macos-14'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}


### PR DESCRIPTION
- Upgrade actions/checkout v4 → v5 (https://github.com/actions/checkout/releases/tag/v5.0.0)
- Upgrade actions/setup-node v4 → v6 (https://github.com/actions/setup-node/releases/tag/v6.0.0)