### PR TITLE
fix(android): separate local storage between WebView processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [3.0.3](https://github.com/ionic-team/capacitor-os-inappbrowser/compare/v3.0.2...v3.0.3) (2026-04-17)
+
+
+### Bug Fixes
+
+* **android:** Duplicate requests for checking if a url hosts PDF ([#108](https://github.com/ionic-team/capacitor-os-inappbrowser/issues/108)) ([f752a54](https://github.com/ionic-team/capacitor-os-inappbrowser/commit/f752a54416dfcb3aeeaa86ea87e07dc729fa9080))
+* **ios:** `window.open()` and `target="_blank"` inside webview ([#110](https://github.com/ionic-team/capacitor-os-inappbrowser/issues/110)) ([5490786](https://github.com/ionic-team/capacitor-os-inappbrowser/commit/54907860483b6bc1db976c8f782e0ffe1523ffb3))
+
 ## [3.0.2](https://github.com/ionic-team/capacitor-os-inappbrowser/compare/v3.0.1...v3.0.2) (2026-02-11)
 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ npx cap sync
 - iOS
 - Android
 
+#### LocalStorage Isolation
+The `openInWebView` option provides isolation for `localStorage` and `cookies` to ensure that content loaded in the InAppBrowser does not interfere with the main application's storage.
+
+- **iOS**: Storage is isolated by default.
+- **Android (API 28+)**: Storage is isolated by running the InAppBrowser in a separate process (`:OSInAppBrowser`) with a dedicated data directory suffix.
+- **Android (API < 28)**: Storage is **shared** with the main application due to platform limitations. On these devices, if the URL opened has the same origin as the main app, they will share the same `localStorage`.
+
 #### Android
 
 The InAppBrowser plugin requires a minimum Android SDK target of 26. This is higher than the default that comes with your Capacitor application. You can update this value in your `android/variables.gradle` file.

--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ npx cap sync
 - iOS
 - Android
 
-#### LocalStorage Isolation
-The `openInWebView` option provides isolation for `localStorage` and `cookies` to ensure that content loaded in the InAppBrowser does not interfere with the main application's storage.
-
-- **iOS**: Storage is isolated by default.
-- **Android (API 28+)**: Storage is isolated by running the InAppBrowser in a separate process (`:OSInAppBrowser`) with a dedicated data directory suffix.
-- **Android (API < 28)**: Storage is **shared** with the main application due to platform limitations. On these devices, if the URL opened has the same origin as the main app, they will share the same `localStorage`.
-
 #### Android
 
 The InAppBrowser plugin requires a minimum Android SDK target of 26. This is higher than the default that comes with your Capacitor application. You can update this value in your `android/variables.gradle` file.
@@ -30,6 +23,24 @@ ext {
     minSdkVersion = 26
 }
 ```
+
+#### LocalStorage Isolation
+The `openInWebView` option provides isolation for `localStorage` and `cookies` to ensure that content loaded in the InAppBrowser does not interfere with the main application's storage.
+
+- **iOS**: Storage is isolated by default.
+- **Android (API 28+)**: Storage is **isolated by default** by running the InAppBrowser in a separate process (`:OSInAppBrowser`) with a dedicated data directory suffix.
+- **Android (API < 28)**: Storage is **shared** with the main application due to platform limitations.
+
+### Opting-out of Isolation (Android)
+If your use case requires sharing `localStorage` or `cookies` between the main app and the InAppBrowser on Android, you can opt-out of isolation by setting `isIsolated: false` in the `android` options.
+
+> [!CAUTION]
+> Disabling isolation reduces the security of your app by allowing potentially untrusted web content to access your application's private storage (Cookies, LocalStorage, etc.). Use this only if absolutely necessary.
+
+> [!WARNING]
+> **Breaking Change (Android)**: Apps upgrading to this version will lose any existing `localStorage` or cookies previously stored by the InAppBrowser on the first run. This is because the WebView now runs in a separate process with its own data directory. Users may need to re-authenticate with websites that relied on persisted session data.
+
+---
 
 ## Usage Example
 #### Open In External Browser
@@ -246,6 +257,7 @@ Defines the options for opening a URL in the web view.
 | **`allowZoom`**    | <code>boolean</code> | Shows the Android browser's zoom controls.                                                                                                 |
 | **`hardwareBack`** | <code>boolean</code> | Uses the hardware back button to navigate backwards through the Web View's history. If there is no previous page, the Web View will close. |
 | **`pauseMedia`**   | <code>boolean</code> | Makes the Web View pause/resume with the app to stop background audio.                                                                     |
+| **`isIsolated`**   | <code>boolean</code> | Whether to run the InAppBrowser in an isolated process. Android only. Defaults to true.                                                    |
 
 
 #### iOSWebViewOptions

--- a/README.md
+++ b/README.md
@@ -34,11 +34,17 @@ The `openInWebView` option provides isolation for `localStorage` and `cookies` t
 ### Opting-out of Isolation (Android)
 If your use case requires sharing `localStorage` or `cookies` between the main app and the InAppBrowser on Android, you can opt-out of isolation by setting `isIsolated: false` in the `android` options.
 
-> [!CAUTION]
-> Disabling isolation reduces the security of your app by allowing potentially untrusted web content to access your application's private storage (Cookies, LocalStorage, etc.). Use this only if absolutely necessary.
+:::caution
 
-> [!WARNING]
-> **Breaking Change (Android)**: Apps upgrading to this version will lose any existing `localStorage` or cookies previously stored by the InAppBrowser on the first run. This is because the WebView now runs in a separate process with its own data directory. Users may need to re-authenticate with websites that relied on persisted session data.
+Disabling isolation reduces the security of your app by allowing potentially untrusted web content to access your application's private storage (Cookies, LocalStorage, etc.). Use this only if absolutely necessary.
+
+:::
+
+:::warning
+
+**Breaking Change (Android)**: Apps upgrading to this version will lose any existing `localStorage` or cookies previously stored by the InAppBrowser on the first run. This is because the WebView now runs in a separate process with its own data directory. Users may need to re-authenticate with websites that relied on persisted session data.
+
+:::
 
 ---
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation("io.ionic.libs:ioninappbrowser-android:1.6.1")
+    implementation("io.ionic.libs:ioninappbrowser-android:1.7.0")
     implementation "androidx.browser:browser:$androidxBrowserVersion"
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,16 +22,6 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-def osInAppBrowserLibsDir = file('libs')
-
-rootProject.allprojects {
-    repositories {
-        flatDir {
-            dirs osInAppBrowserLibsDir
-        }
-    }
-}
-
 android {
     namespace = "com.capacitorjs.osinappbrowser"
     compileSdk = project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 36
@@ -69,8 +59,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    // implementation("io.ionic.libs:ioninappbrowser-android:2.0.0")
-    implementation(name: "OSInAppBrowserLib-debug", ext: "aar")
+    implementation("io.ionic.libs:ioninappbrowser-android:2.0.0")
     implementation "androidx.browser:browser:$androidxBrowserVersion"
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,16 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+def osInAppBrowserLibsDir = file('libs')
+
+rootProject.allprojects {
+    repositories {
+        flatDir {
+            dirs osInAppBrowserLibsDir
+        }
+    }
+}
+
 android {
     namespace = "com.capacitorjs.osinappbrowser"
     compileSdk = project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 36
@@ -54,9 +64,6 @@ kotlin {
 repositories {
     google()
     mavenCentral()
-    flatDir {
-        dirs 'libs'
-    }
 }
 
 dependencies {

--- a/android/src/main/java/com/capacitorjs/osinappbrowser/InAppBrowserPlugin.kt
+++ b/android/src/main/java/com/capacitorjs/osinappbrowser/InAppBrowserPlugin.kt
@@ -57,6 +57,7 @@ class InAppBrowserPlugin : Plugin() {
                         notifyListeners(OSIABEventType.BROWSER_PAGE_LOADED.value, null)
                     },
                     onBrowserFinished = {
+                        activeRouter = null
                         notifyListeners(OSIABEventType.BROWSER_FINISHED.value, null)
                     }
                 )
@@ -97,6 +98,7 @@ class InAppBrowserPlugin : Plugin() {
                         notifyListeners(OSIABEventType.BROWSER_PAGE_LOADED.value, null)
                     },
                     onBrowserFinished = {
+                        activeRouter = null
                         notifyListeners(OSIABEventType.BROWSER_FINISHED.value, null)
                     },
                     onBrowserPageNavigationCompleted = {
@@ -183,7 +185,8 @@ class InAppBrowserPlugin : Plugin() {
                 allowZoom = androidOptions?.getBoolean("allowZoom", true) ?: true,
                 hardwareBack = androidOptions?.getBoolean("hardwareBack", true) ?: true,
                 pauseMedia = androidOptions?.getBoolean("pauseMedia", true) ?: true,
-                customUserAgent = it.getString("customWebViewUserAgent", null)
+                customUserAgent = it.getString("customWebViewUserAgent", null),
+                isIsolated = androidOptions?.getBoolean("isIsolated", true) ?: it.getBoolean("isIsolated", true) ?: true
             )
         }
     }

--- a/android/src/main/java/com/capacitorjs/osinappbrowser/InAppBrowserPlugin.kt
+++ b/android/src/main/java/com/capacitorjs/osinappbrowser/InAppBrowserPlugin.kt
@@ -57,7 +57,6 @@ class InAppBrowserPlugin : Plugin() {
                         notifyListeners(OSIABEventType.BROWSER_PAGE_LOADED.value, null)
                     },
                     onBrowserFinished = {
-                        activeRouter = null
                         notifyListeners(OSIABEventType.BROWSER_FINISHED.value, null)
                     }
                 )
@@ -98,7 +97,6 @@ class InAppBrowserPlugin : Plugin() {
                         notifyListeners(OSIABEventType.BROWSER_PAGE_LOADED.value, null)
                     },
                     onBrowserFinished = {
-                        activeRouter = null
                         notifyListeners(OSIABEventType.BROWSER_FINISHED.value, null)
                     },
                     onBrowserPageNavigationCompleted = {

--- a/example-app/src/App.tsx
+++ b/example-app/src/App.tsx
@@ -2,6 +2,8 @@ import { Redirect, Route } from 'react-router-dom';
 import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import Home from './pages/Home';
+import LocalStorageTest from './pages/LocalStorageTest';
+
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -41,6 +43,9 @@ const App: React.FC = () => (
       <IonRouterOutlet>
         <Route exact path="/home">
           <Home />
+        </Route>
+        <Route exact path="/local-storage-test">
+          <LocalStorageTest />
         </Route>
         <Route exact path="/">
           <Redirect to="/home" />

--- a/example-app/src/pages/Home.tsx
+++ b/example-app/src/pages/Home.tsx
@@ -1,8 +1,13 @@
-import { IonButton, IonContent, IonHeader, IonInput, IonPage, IonTitle, IonToolbar } from '@ionic/react';
+import React, { useState } from 'react';
+import { IonButton, IonContent, IonHeader, IonInput, IonPage, IonTitle, IonToolbar, useIonRouter, IonItem, IonLabel, IonToggle } from '@ionic/react';
 import { InAppBrowser, DefaultSystemBrowserOptions, DefaultWebViewOptions, DefaultAndroidWebViewOptions, DismissStyle, iOSViewStyle, iOSAnimation, ToolbarPosition, AndroidViewStyle, AndroidAnimation, BrowserPageNavigationCompletedEventData } from '@capacitor/inappbrowser';
 import './Home.css';
 
 const Home: React.FC = () => {
+
+  const [testUrl, setTestUrl] = useState("https://mdn.github.io/dom-examples/web-storage/");
+  const [showIframe, setShowIframe] = useState(false);
+  const [isIsolated, setIsIsolated] = useState(true);
 
   const openInExternalBrowser = () => {
     InAppBrowser.openInExternalBrowser({
@@ -22,7 +27,7 @@ const Home: React.FC = () => {
         alert("Error: Unknown error");
       }
     }
-    
+
   }
 
   const openInSystemBrowserWithDefaults = () => {
@@ -151,6 +156,32 @@ const Home: React.FC = () => {
     InAppBrowser.close();
   }
 
+  const router = useIonRouter();
+
+  const toggleIframe = () => {
+    setShowIframe(!showIframe);
+  };
+
+  const openLocalStorageTestInWebView = () => {
+    // We open the local storage test page in the InAppBrowser
+    // NOTE: On Android with Process Isolation, 'http://localhost' may 404
+    // because the new process doesn't have the Capacitor local server.
+    // For a true same-origin test, use a remote URL.
+    InAppBrowser.openInWebView({
+      url: testUrl,
+      options: {
+        ...DefaultWebViewOptions,
+        showURL: true,
+        showToolbar: true,
+        clearCache: false,
+        android: {
+          ...DefaultAndroidWebViewOptions,
+          isIsolated: isIsolated
+        }
+      }
+    });
+  }
+
   InAppBrowser.addListener('browserClosed', () => {
     console.log("browser was closed.");
   });
@@ -185,8 +216,48 @@ const Home: React.FC = () => {
           <IonButton onClick={openInWebViewWithMoreCustomValues}>Web View with More Custom Values</IonButton>
           <IonButton onClick={openInSystemBrowserThenClose}>Open System Browser then Close</IonButton>
           <IonButton onClick={openInWebViewThenClose}>Open Web View then Close</IonButton>
-          <IonButton onClick={close}>Close opened Browser</IonButton>
           <IonButton onClick={invalidScheme}>Invalid URL Scheme</IonButton>
+
+          <div style={{ padding: '10px', margin: '10px', border: '1px solid #ccc', borderRadius: '8px' }}>
+            <h3>Isolation Test</h3>
+            <IonItem>
+              <IonLabel position="stacked">Test URL</IonLabel>
+              <IonInput value={testUrl} onIonChange={e => setTestUrl(e.detail.value!)} />
+            </IonItem>
+            <IonItem>
+              <IonLabel>Enable Storage Isolation (Android)</IonLabel>
+              <IonToggle checked={isIsolated} onIonChange={e => setIsIsolated(e.detail.checked)} />
+            </IonItem>
+            <p style={{ fontSize: '0.8em', color: '#666' }}>
+              <strong>To replicate shared storage on API &lt; 28:</strong><br />
+              1. Show the "Site Setter" below.<br />
+              2. Use the embedded page to set a value.<br />
+              3. Tap "2. Open Site (InAppBrowser)". It should share the value.<br />
+              <br />
+              <strong>On API 28+ (Isolated):</strong><br />
+              The value will NOT be shared.
+            </p>
+            <IonButton expand="block" color="secondary" onClick={toggleIframe}>
+              {showIframe ? "Hide Site Setter" : "1. Show Site Setter (Main App)"}
+            </IonButton>
+
+            {showIframe && (
+              <div style={{ margin: '10px 0', border: '2px solid #3880ff', borderRadius: '4px', overflow: 'hidden' }}>
+                <p style={{ padding: '5px', margin: 0, backgroundColor: '#3880ff', color: 'white', fontSize: '0.8em', textAlign: 'center' }}>
+                  Main App Context (Iframe)
+                </p>
+                <iframe
+                  src={testUrl}
+                  style={{ width: '100%', height: '300px', border: 'none' }}
+                  title="Storage Setter"
+                />
+              </div>
+            )}
+
+            <IonButton expand="block" color="tertiary" onClick={openLocalStorageTestInWebView}>2. Open Site (InAppBrowser)</IonButton>
+            <IonButton expand="block" fill="outline" onClick={() => router.push('/local-storage-test')}>Go to Local Test Component</IonButton>
+          </div>
+
           <IonInput placeholder="Enter text here..." />
         </div>
       </IonContent>

--- a/example-app/src/pages/LocalStorageTest.tsx
+++ b/example-app/src/pages/LocalStorageTest.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonButton, IonInput, IonItem, IonLabel, IonList, IonButtons, IonBackButton } from '@ionic/react';
+
+const LocalStorageTest: React.FC = () => {
+  const [value, setValue] = useState('');
+  const [storedValue, setStoredValue] = useState<string | null>(null);
+
+  const refreshValue = () => {
+    const val = localStorage.getItem('inappbrowser_test_key');
+    setStoredValue(val);
+  };
+
+  useEffect(() => {
+    refreshValue();
+  }, []);
+
+  const saveValue = () => {
+    localStorage.setItem('inappbrowser_test_key', value);
+    refreshValue();
+  };
+
+  const clearValue = () => {
+    localStorage.removeItem('inappbrowser_test_key');
+    refreshValue();
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/home" />
+          </IonButtons>
+          <IonTitle>LocalStorage Test</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <IonList>
+          <IonItem>
+            <IonLabel position="stacked">Test Value</IonLabel>
+            <IonInput value={value} onIonChange={(e: any) => setValue(e.detail.value!)} placeholder="Enter value to store" />
+          </IonItem>
+        </IonList>
+        <div style={{ marginTop: '20px' }}>
+          <IonButton expand="block" onClick={saveValue}>Save to LocalStorage</IonButton>
+          <IonButton expand="block" color="light" onClick={refreshValue}>Refresh from LocalStorage</IonButton>
+          <IonButton expand="block" color="danger" onClick={clearValue}>Clear LocalStorage</IonButton>
+        </div>
+
+        <div style={{ marginTop: '40px' }}>
+          <h3>Stored Value:</h3>
+          <p style={{ fontSize: '24px', fontWeight: 'bold' }}>{storedValue || '(none)'}</p>
+        </div>
+
+        <div style={{ marginTop: '20px', padding: '10px', backgroundColor: '#f0f0f0', borderRadius: '8px' }}>
+          <p><strong>Instructions:</strong></p>
+          <ol>
+            <li>Set a value here in the main app.</li>
+            <li>Go back and open this same page using "Open Site (InAppBrowser)".</li>
+            <li>Use the <strong>Enable Storage Isolation</strong> toggle to test different modes.
+              <ul>
+                <li><strong>On (Default)</strong>: Value should be "(none)".</li>
+                <li><strong>Off</strong>: Value should be shared.</li>
+              </ul>
+            </li>
+          </ol>
+        </div>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default LocalStorageTest;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/inappbrowser",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "The InAppBrowser Plugin provides a web browser view that allows you to load any web page externally. It behaves as a standard web browser and is useful to load untrusted content without risking your application's security. It offers three different ways to open URLs; in a WebView, in an in-app system browser (Custom Tabs for Android and SFSafariViewController for iOS), and in the device's default browser.",
   "main": "./dist/plugin.cjs",
   "module": "./dist/plugin.mjs",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "files": [
     "android/src/main/",
     "android/build.gradle",
-    "android/libs/",
     "dist/",
     "ios/Sources",
     "ios/Tests",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "files": [
     "android/src/main/",
     "android/build.gradle",
+    "android/libs/",
     "dist/",
     "ios/Sources",
     "ios/Tests",
@@ -52,6 +53,7 @@
     "build": "npm run clean && npm run docgen && vite build",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release"
   },

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -17,6 +17,7 @@ export const DefaultAndroidWebViewOptions: AndroidWebViewOptions = {
   allowZoom: false,
   hardwareBack: true,
   pauseMedia: true,
+  isIsolated: true,
 };
 
 export const DefaultiOSWebViewOptions: iOSWebViewOptions = {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -90,6 +90,8 @@ export interface AndroidWebViewOptions {
   hardwareBack: boolean;
   /** Makes the Web View pause/resume with the app to stop background audio. */
   pauseMedia: boolean;
+  /** Whether to run the InAppBrowser in an isolated process. Android only. Defaults to true. */
+  isIsolated?: boolean;
 }
 
 /* eslint-disable no-unused-vars */


### PR DESCRIPTION
This PR updates the Android library to `2.0.0` and documents the relevant fix for isolating `localStorage` on Android.

Context: https://github.com/OutSystems/OSInAppBrowserLib-Android/pull/54

[MABS 12 Capacitor (BUILD 3)](https://eng-mobile.outsystems.dev/apps/packagehistory?id=e37fdef4-7ecc-4431-9607-d7fdac4e3e30&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b)

Steps to reproduce:
The new page includes the setting for IsIsolated and then a toggle for showing an iframe of a website where you can change some stored values like background color, font type, etc... Then there is a button for going to the same URL on the WebView. If storage is isolated then the values won't persist, but if it's toggled off or you are testing on an older device, then the values will be the same as the iframe.