### PR TITLE
fix(android): Duplicate requests for checking if a url hosts PDF

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation("io.ionic.libs:ioninappbrowser-android:1.6.1")
+    implementation("io.ionic.libs:ioninappbrowser-android:1.6.2")
     implementation "androidx.browser:browser:$androidxBrowserVersion"
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"


### PR DESCRIPTION
Clone of https://github.com/OutSystems/cordova-outsystems-inappbrowser/pull/71 but for Capacitor. The fix was originally intended for OutSystems Cordova apps, but may also benefit Capacitor.