### PR TITLE
ci: Fix error with install latest version of npm on ubuntu

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -10,7 +10,7 @@ runs:
         node-version: 22 # semantic-release requires at least this version
     - name: Update npm # To ensure npm 11.5.1 or later is installed for Trusted publishing
       shell: bash
-      run: npm install -g npm@latest
+      run: npm install -g npm@~11.10.0
     - name: Install dependencies
       shell: bash
       run: npm i


### PR DESCRIPTION
To fix https://github.com/ionic-team/capacitor-os-inappbrowser/actions/runs/24561617861/job/71811377504?pr=108

```
Run npm install -g npm@latest
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
```

Once this is fixed on npm side, we can review updating the version in a future PR.