### PR TITLE
fix(android): bump ioninappbrowser-android to 2.0.1 for Android 18 URI grant fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation("io.ionic.libs:ioninappbrowser-android:2.0.0")
+    implementation("io.ionic.libs:ioninappbrowser-android:2.0.1")
     implementation "androidx.browser:browser:$androidxBrowserVersion"
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"


### PR DESCRIPTION
## Summary
This plugin delegates entirely to `OSIABEngine`/`OSIABRouter` in `OSInAppBrowserLib-Android` for the WebView file-chooser photo/video capture flow. `OSInAppBrowserLib-Android` 2.0.1 explicitly grants `FLAG_GRANT_READ_URI_PERMISSION`/`FLAG_GRANT_WRITE_URI_PERMISSION` on the capture intents, required by Android 18's implicit URI grant restriction ([OSInAppBrowserLib-Android#57](https://github.com/OutSystems/OSInAppBrowserLib-Android/pull/57)).

- Bump `ioninappbrowser-android` from 2.0.0 to 2.0.1.

Part of [RMET-5241](https://outsystemsrd.atlassian.net/browse/RMET-5241).

**Draft**: `ioninappbrowser-android:2.0.1` is not yet published to Maven Central — this PR is blocked on that release landing. Do not merge until then.

## Test plan
- [x] Manual: exercised `openInWebView` -> takePhoto and recordVideo, built locally against a local Maven artifact for `ioninappbrowser-android:2.0.1`. Confirmed both work on Android 8 (this library's minSdk) and Android 17.

[RMET-5241]: https://outsystemsrd.atlassian.net/browse/RMET-5241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ