### PR TITLE
ci: verify plugin builds natively

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -14,3 +14,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: npm i
+    - name: Set Xcode 26.0  # minimum support Xcode version by Capacitor 8
+      if: runner.os == 'macOS'
+      shell: bash
+      run: sudo xcode-select --switch /Applications/Xcode_26.0.app

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -17,3 +17,19 @@ jobs:
   build-packages:
     needs: 'setup'
     uses: ./.github/workflows/reusable_build.yml
+
+  verify:
+    needs: 'setup'
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+
+      - name: 'Verify'
+        shell: bash
+        run: npm run verify

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -18,7 +18,7 @@ jobs:
     needs: 'setup'
     uses: ./.github/workflows/reusable_build.yml
 
-  verify:
+  verify-plugin-android:
     needs: 'setup'
     runs-on: 'macos-15'
     timeout-minutes: 30
@@ -26,10 +26,22 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
-
-      - name: 'Verify'
+      - name: 'Verify Android'
         shell: bash
-        run: npm run verify
+        run: npm run verify:android
+
+  verify-plugin-ios:
+    needs: 'setup'
+    runs-on: 'macos-15'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: 'Setup Tools'
+        uses: ./.github/actions/setup-tools
+      - name: 'Verify iOS'
+        shell: bash
+        run: npm run verify:ios


### PR DESCRIPTION
We usually do `npm run verify` in CI for Capacitor plugins, was missing in this one.